### PR TITLE
Reduce the visibility of letter methods

### DIFF
--- a/generator/adn.py
+++ b/generator/adn.py
@@ -131,7 +131,7 @@ def generate_letter_functions(merged_dict):
     Generates a java method for each letter to make sure each method
     is below the 64K java limit.  e.g.
 
-        public static String $letterMethod(String model) {
+        private static String $letterMethod(String model) {
             // models starting with letter $letter
             $letter_devices
         }

--- a/generator/templates/java_letter.template
+++ b/generator/templates/java_letter.template
@@ -1,3 +1,3 @@
-    public static String $letter_method (String model) {
+    private static String $letter_method (String model) {
         $letter_devices
     }


### PR DESCRIPTION
The letters methods are used internally only and should not be exposed to the users of DeviceNames class.
